### PR TITLE
Actually fix #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ $ npm install async-memoize-one --save
 ## Usage
 
 ```js
-import memoizeOne from 'async-memoize-one'
-import got from 'got'
+const get = require('util').promisify(require('simple-get'))
+const memoizeOne = require('async-memoize-one')
 
-const fetchData = memoizeOne(url => got(`https://api.microlink.io?url=${url}`))
+const fetchData = memoizeOne(url => get(`https://api.microlink.io?url=${url}`))
 
 ;(async () => {
   // fecthing data for first time

--- a/README.md
+++ b/README.md
@@ -26,23 +26,31 @@ $ npm install async-memoize-one --save
 ## Usage
 
 ```js
-const memoizeOne = require('async-memoize-one')
-const got = require('got')
+import memoizeOne from 'async-memoize-one'
+import got from 'got'
 
-const fetchData = url => memoizeOne(got(`https://api.microlink.io?url=${url}`))
+const fetchData = memoizeOne(url => got(`https://api.microlink.io?url=${url}`))
 
 ;(async () => {
   // fecthing data for first time
+  console.time('fetch')
   await fetchData('https://example.com/one')
+  console.timeEnd('fetch')
 
   // served data from cache; no fetching!
+  console.time('fetch')
   await fetchData('https://example.com/one')
+  console.timeEnd('fetch')
 
   // previous execution parameters are different, so fetching again
+  console.time('fetch')
   await fetchData('https://example.com/two')
+  console.timeEnd('fetch')
 
   // previous execution parameters are different, so fetching again
+  console.time('fetch')
   await fetchData('https://example.com/one')
+  console.timeEnd('fetch')
 })()
 ```
 


### PR DESCRIPTION
1. You didn't actually wrap `memoizeOne` correctly (you wrapped the result of `got`, not the function)
2. `got` is only available as ESM (https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c), so your example didn't actually work at all (`ERR_REQUIRE_ESM`)

Now it also outputs "proof" what it does:

```
fetch: 199.701ms
fetch: 0.099ms
fetch: 144.258ms
fetch: 133.848ms
```